### PR TITLE
Numpy optimization for SpecReBoot codebase

### DIFF
--- a/specreboot/bootstrapping/bootstrapping.py
+++ b/specreboot/bootstrapping/bootstrapping.py
@@ -35,9 +35,6 @@ def calculate_bootstrapping(
 
     total_start = time.perf_counter()
 
-    if verbose:
-        print(f"Running {B} bootstraps in {len(batches)} batches (batch_size={batch_size}) with {n_jobs} workers", flush=True)
-
     # NOTE: due to floating point arithmatic, the resulting values in the cosine similarity matrix might differ with the orignal function with around <1e-7. 
     history = {}
     
@@ -54,9 +51,13 @@ def calculate_bootstrapping(
     bootstrap_ids = list(range(B))
     batches = [bootstrap_ids[i:i + batch_size] for i in range(0, B, batch_size)]
 
+    if verbose:
+        print(f"Running {B} bootstraps in {len(batches)} batches (batch_size={batch_size}) with {n_jobs} workers", flush=True)
+
     compute_start = time.perf_counter()
 
-    args = [(spectra_binned, global_bins, similarity_metric, k, b, seed) for b in batches]
+    args = [(spectra_binned, global_bins, similarity_metric, seed, k, b, return_history, track_bins, verbose) for b in batches]
+
     with ThreadPoolExecutor(max_workers=n_jobs) as executor:
         results = list(executor.map(lambda x: bootstrap_batch(*x), args))
 

--- a/specreboot/bootstrapping/bootstrapping.py
+++ b/specreboot/bootstrapping/bootstrapping.py
@@ -22,28 +22,60 @@ def calculate_bootstrapping(
     return_label_map=True,
     verbose: bool = True,
 ):
-    """
-    Bootstrapped mean similarity + mutual-kNN edge support.
+    """Calculate bootstrapped mean similarity and mutual-kNN edge support for a single replicate.
+
+    Parameters
+    -------
+    spectra_binned (list[Spectrum]): List of binned spectra.
+    global_bins (array-like): Global m/z bins used as the bootstrap sampling space.
+    B : int
+        Number of bootstrap replicates.
+    k : int
+        Number of nearest neighbors used for mutual-kNN edge support.
+    similarity_metric : callable
+        Similarity object used to calculate pairwise similarities.
+    n_jobs : int
+        Number of workers used for parallel batch execution.
+    batch_size : int
+        Number of bootstrap replicates processed per batch.
+    seed : int
+        Base random seed for bootstrap resampling.
+    return_history : bool
+        Whether to return cumulative bootstrap history.
+    track_bins : bool
+        Whether to store sampled and missing bins for each bootstrap.
+    label_mode : str
+        Output label type. Options are "feature", "scan", or "internal".
+    return_label_map : bool
+        Whether to return the mapping between output labels and
+        original spectrum identifiers.
+    verbose : bool
+        Whether to print progress and timing information.
 
     Returns
     -------
-    If return_history is False:
-        df_mean_sim, df_edge_sup                 (and label_map if return_label_map True)
-    If return_history is True:
-        df_mean_sim, df_edge_sup, history        (history may include label_map)
+    tuple:
+    - If return_history is False and return_label_map is False:
+      (df_mean_sim, df_edge_sup)
+    - If return_history is False and return_label_map is True:
+      (df_mean_sim, df_edge_sup, label_map)
+    - If return_history is True:
+      (df_mean_sim, df_edge_sup, history)
     """
-
     total_start = time.perf_counter()
 
     # NOTE: due to floating point arithmatic, the resulting values in the cosine similarity matrix might differ with the orignal function with around <1e-7. 
     history = {}
-    
-    global_bins = np.array(global_bins)  # Important, a simple list will raise an error
 
+    # The similarity implementation expects a NumPy array of global bins.
+    global_bins = np.array(global_bins)
+
+    # Build output labels and label map for the selected label mode.
     out_labels, label_info = _get_spectra_labels(label_mode, spectra_binned)
 
     dataset_size = len(spectra_binned)
 
+    # Accumulate results across all bootstrap replicates.
     total_pair_similarities = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the sum of all similarities of each pair combination
     total_pair_counts       = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair is used in the bootstrapping
     total_edge_support      = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair are each others closest k neighbours
@@ -73,7 +105,7 @@ def calculate_bootstrapping(
     for result in results:
         pair_similarities, pair_counts, edge_support, batch_history = result
 
-        # Add the results if this iteration
+        # Add the batch results to the global totals.
         total_pair_similarities += pair_similarities
         total_pair_counts       += pair_counts
         total_edge_support      += edge_support
@@ -88,14 +120,15 @@ def calculate_bootstrapping(
 
 
      
-    # Get the average of similarities
+    # Calculate the mean similarity only where a pair was observed.
     mean_similarities = np.divide(
         total_pair_similarities,
         total_pair_counts,
         out=np.zeros_like(total_pair_similarities, dtype=float),
         where=total_pair_counts != 0
     )
-    np.fill_diagonal(mean_similarities , 1)  # needed to exactly match original implementation; all spectra have a similarity of 1 to themselves
+    # Self-similarity is fixed to 1 to match the original implementation.
+    np.fill_diagonal(mean_similarities , 1)
     mean_edge_support = total_edge_support / B
 
     # Needed to match correct return type
@@ -148,11 +181,40 @@ def bootstrap_batch(
     track_bins=False,
     verbose=False,
 ):
+    """Run a batch of bootstrap replicates.
+
+    Parameters
+    -------
+    spectra_binned : list[Spectrum]
+        List of binned spectra.
+    global_bins : np.ndarray
+        Global m/z bins used for resampling.
+    similarity_metric: callable
+        Similarity object used to calculate pairwise similarities.
+    seed : int
+        Base random seed.
+    k : int
+        Number of nearest neighbors used for mutual-kNN support.
+    B : list[int]
+        Bootstrap replicate indices processed in this batch.
+    collect_history : bool
+        Whether to store per-bootstrap results.
+    track_bins : bool
+        Whether to store sampled and missing bins for each bootstrap.
+    verbose : bool
+        Whether to print timing information.    
+
+    Returns
+    -------
+    tuple:
+    (total_pair_similarities, total_pair_counts, total_edge_support, history)
+    """
     t_batch_start = time.perf_counter()
 
     dataset_size = len(spectra_binned)
     random_generator = np.random.default_rng(seed)
 
+    # Accumulate results across the bootstrap replicates in this batch.
     total_pair_similarities = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the sum of all similarities of each pair combination
     total_pair_counts       = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair is used in the bootstrapping
     total_edge_support      = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair are each others closest k neighbours
@@ -207,6 +269,18 @@ def bootstrap_batch(
      
 
 def _reconstruct_history(dataset_size, all_history):
+    """Reconstruct cumulative similarity and edge-support history.
+
+    Parameters:
+    dataset_size : int
+        Number of spectra in the dataset.
+    all_history :list[dict]
+        Per-bootstrap history entries.
+
+    Returns:
+    tuple[list[np.ndarray], list[np.ndarray]]:
+    Cumulative mean similarity matrices and cumulative edge-support matrices.
+    """
     history_mean_sim = []
     history_edge_sup = []
 
@@ -235,6 +309,18 @@ def _reconstruct_history(dataset_size, all_history):
 
 
 def _get_spectra_labels(label_mode: str, spectra_binned: list[Spectrum]) -> tuple[list[str], dict[str, any]]:  # Logic from previous main function refactored into a helper function
+    """Create output labels and label map for the selected label mode.
+
+    Parameters:
+    label_mode : str
+        Label mode. Options are "feature", "scan", or "internal".
+    spectra_binned : list[Spectrum]
+        List of binned spectra.
+
+    Returns:
+    tuple[list[str], dict[str, any]]:
+        Output labels and a dictionary containing label_map and label_mode.
+    """
     scan_labels = []
     feature_labels = []
     internal_ids = []
@@ -284,6 +370,7 @@ def _get_spectra_labels(label_mode: str, spectra_binned: list[Spectrum]) -> tupl
 
 
 def __make_unique(labels: list[any]) -> list[str]:
+    """Make labels unique by appending a suffix to duplicated values."""
     counts = Counter(labels)
     seen = Counter()
     out = []
@@ -298,8 +385,15 @@ def __make_unique(labels: list[any]) -> list[str]:
 
 
 def mutual_topk(A: np.ndarray, k: int) -> np.ndarray:
-    """ gives a matrix in the shap of A, where a 1 means a pair are each others top-k neighbor """
+    """Return a binary matrix marking mutual top-k neighbours.
 
+    Parameters:
+    A (np.ndarray): Pairwise similarity matrix.
+    k (int): Number of nearest neighbours to retain per row.
+
+    Returns:
+    np.ndarray: Binary matrix where 1 indicates a mutual top-k relationship.
+    """
     n = A.shape[0]
     A_work = A.copy()
     np.fill_diagonal(A_work, -np.inf)  # This makes sure self-similarity is not counted as a top neighbor
@@ -320,6 +414,20 @@ def mutual_topk(A: np.ndarray, k: int) -> np.ndarray:
 
 
 def _mask_spectra(random_generator: Any, global_bins: np.ndarray, binned_spectra: list[Spectrum]) -> tuple[list[Spectrum], np.ndarray]:
+    """Mask spectra according to one bootstrap sample of the global bins.
+
+    Parameters:
+    random_generator : Any
+        NumPy random generator used for resampling.
+    global_bins : np.ndarray
+        Global m/z bins used for bootstrap sampling.
+    binned_spectra : list[Spectrum]
+        List of binned spectra.
+
+    Returns:
+    tuple[list[Spectrum], np.ndarray]:
+    Masked spectra and the sampled bins used in this bootstrap replicate.
+    """
     result = []
 
     sampled_indices = random_generator.integers(0, len(global_bins), size=len(global_bins))

--- a/specreboot/bootstrapping/bootstrapping.py
+++ b/specreboot/bootstrapping/bootstrapping.py
@@ -121,16 +121,19 @@ def calculate_bootstrapping(
 
     print(f"Total bootstrapping completed in {total_end - total_start:.2f} seconds", flush=True)
 
-
     if track_bins:
         history["sampled_bins"] = [h["sampled_bins"] for h in sorted(all_history, key=lambda x: x["b"])]
         history["missing_bins"] = [h["missing_bins"] for h in sorted(all_history, key=lambda x: x["b"])]
 
+    if return_history:
+        if return_label_map:
+            history |= label_info
+        history = {k: v for k, v in history.items() if len(v) != 0}
+        return df_mean_sim, df_edge_sup, history
+
     if return_label_map:
-        history |= label_info
-    
-    history = {k: v for k, v in history.items() if len(v) != 0}   # purge all missing data
-    return df_mean_sim, df_edge_sup, history
+        return df_mean_sim, df_edge_sup, label_info["label_map"]
+    return df_mean_sim, df_edge_sup
 
 
 

--- a/specreboot/bootstrapping/bootstrapping.py
+++ b/specreboot/bootstrapping/bootstrapping.py
@@ -5,17 +5,22 @@ from tqdm import tqdm
 import pandas as pd
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
+import time
 
-def calculate_boostrapping(
+def calculate_bootstrapping(
     spectra_binned,
     global_bins,
     B=100,
     k=5,
     similarity_metric=None,
-    n_jobs=8,
+    n_jobs=4,
+    batch_size=10,
     seed=42,
-    label_mode: str = "feature",      # "feature" | "scan" | "internal"
-    batch_size: int = 10
+    return_history=False,
+    track_bins=False,
+    label_mode="feature",
+    return_label_map=True,
+    verbose: bool = True,
 ):
     """
     Bootstrapped mean similarity + mutual-kNN edge support.
@@ -27,7 +32,14 @@ def calculate_boostrapping(
     If return_history is True:
         df_mean_sim, df_edge_sup, history        (history may include label_map)
     """
+
+    total_start = time.perf_counter()
+
+    if verbose:
+        print(f"Running {B} bootstraps in {len(batches)} batches (batch_size={batch_size}) with {n_jobs} workers", flush=True)
+
     # NOTE: due to floating point arithmatic, the resulting values in the cosine similarity matrix might differ with the orignal function with around <1e-7. 
+    history = {}
     
     global_bins = np.array(global_bins)  # Important, a simple list will raise an error
 
@@ -42,17 +54,37 @@ def calculate_boostrapping(
     bootstrap_ids = list(range(B))
     batches = [bootstrap_ids[i:i + batch_size] for i in range(0, B, batch_size)]
 
+    compute_start = time.perf_counter()
+
     args = [(spectra_binned, global_bins, similarity_metric, k, b, seed) for b in batches]
     with ThreadPoolExecutor(max_workers=n_jobs) as executor:
         results = list(executor.map(lambda x: bootstrap_batch(*x), args))
 
+    compute_end = time.perf_counter()
+
+    if verbose:
+        print(f"Bootstrap batch execution finished in {compute_end - compute_start:.2f} seconds", flush=True)
+
+    all_history = []
+
+    merge_start = time.perf_counter()
+
     for result in results:
-        pair_similarities, pair_counts, edge_support = result
+        pair_similarities, pair_counts, edge_support, batch_history = result
 
         # Add the results if this iteration
         total_pair_similarities += pair_similarities
         total_pair_counts       += pair_counts
         total_edge_support      += edge_support
+        all_history             += batch_history
+
+    merge_end = time.perf_counter()
+    total_end = time.perf_counter()
+
+    if verbose:
+        print(f"Merge finished in {merge_end - merge_start:.2f} seconds", flush=True)
+        print(f"Total bootstrapping completed in {total_end - total_start:.2f} seconds", flush=True)
+
 
      
     # Get the average of similarities
@@ -69,11 +101,51 @@ def calculate_boostrapping(
     df_mean_sim = pd.DataFrame(mean_similarities, index=out_labels, columns=out_labels)
     df_edge_sup = pd.DataFrame(mean_edge_support, index=out_labels, columns=out_labels)
 
-    # Return history according to settings
-    return df_mean_sim, df_edge_sup
+    if return_history:
+        if verbose:
+            print("Reconstructing cumulative history from per-bootstrap results...", flush=True)
+
+        replay_start = time.perf_counter()
+
+        history_mean_sim, history_edge_sup = _reconstruct_history(dataset_size, all_history)
+        history["mean_sim"] = history_mean_sim
+        history["edge_sup"] = history_edge_sup
+
+        replay_end = time.perf_counter()
+
+        if verbose:
+            print(f"History reconstruction finished in {replay_end - replay_start:.2f} seconds", flush=True)
+
+    total_end = time.perf_counter()
+
+    print(f"Total bootstrapping completed in {total_end - total_start:.2f} seconds", flush=True)
 
 
-def bootstrap_batch(spectra_binned: list[Spectrum], global_bins: np.array, similarity_metric, k: int, b: list[int], seed: int):
+    if track_bins:
+        history["sampled_bins"] = [h["sampled_bins"] for h in sorted(all_history, key=lambda x: x["b"])]
+        history["missing_bins"] = [h["missing_bins"] for h in sorted(all_history, key=lambda x: x["b"])]
+
+    if return_label_map:
+        history |= label_info
+    
+    history = {k: v for k, v in history.items() if len(v) != 0}   # purge all missing data
+    return df_mean_sim, df_edge_sup, history
+
+
+
+def bootstrap_batch(                
+    spectra_binned,
+    global_bins,
+    similarity_metric,
+    seed,
+    k,
+    B,
+    collect_history=False,
+    track_bins=False,
+    verbose=False,
+):
+    t_batch_start = time.perf_counter()
+
     dataset_size = len(spectra_binned)
     random_generator = np.random.default_rng(seed)
 
@@ -81,30 +153,81 @@ def bootstrap_batch(spectra_binned: list[Spectrum], global_bins: np.array, simil
     total_pair_counts       = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair is used in the bootstrapping
     total_edge_support      = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair are each others closest k neighbours
 
-    for b in tqdm(b):
+    history = []
+
+    for b in tqdm(B):
 
         masked_spectra, sampled_bins = _mask_spectra(random_generator, global_bins, spectra_binned)
 
         # This is different now, but matches the internal workings of calculate_scores from matchms module
-        similarity_matrix = similarity_metric.matrix(masked_spectra, masked_spectra, array_type="numpy", is_symmetric=True)
+        pair_similarity_matrix = similarity_metric.matrix(masked_spectra, masked_spectra, array_type="numpy", is_symmetric=True)
 
-        top_k_nearest_neighbours = mutual_topk(similarity_matrix, k)
+        top_k_nearest_neighbours = mutual_topk(pair_similarity_matrix, k)
 
         # Get the position of the pairs that we used in this iteration
-        similarity_matrix_binary        = (similarity_matrix != 0).astype(int)
-        top_k_nearest_neighbours_binary = (top_k_nearest_neighbours != 0).astype(int)
+        pair_counts  = (pair_similarity_matrix != 0).astype(int)
+        edge_support = (top_k_nearest_neighbours != 0).astype(int)
 
         # Add the results if this iteration
-        total_pair_similarities += similarity_matrix
-        total_pair_counts       += similarity_matrix_binary
-        total_edge_support      += top_k_nearest_neighbours_binary
+        total_pair_similarities += pair_similarity_matrix
+        total_pair_counts       += pair_counts
+        total_edge_support      += edge_support
+
+        run = {}
+        history.append(run)
+        if collect_history:
+            
+            run["b"] = b
+            run["pair_sim_sum"] = pair_similarity_matrix
+            run["pair_counts"]  = pair_counts
+            run["edge_support"] = edge_support
+
+
+        if track_bins:
+            used_bins   = np.unique(sampled_bins)
+            unused_bins = np.setdiff1d(global_bins, sampled_bins)
+
+            run["sampled_bins"] = used_bins
+            run["missing_bins"] = unused_bins
+
+    t_batch_end = time.perf_counter()
+    if verbose:
+        print(f"Batch {B[0]}-{B[-1]} finished in {t_batch_end - t_batch_start:.2f} s", flush=True)
 
     return (
         total_pair_similarities, 
         total_pair_counts,        
         total_edge_support,    
+        history
     )
      
+
+def _reconstruct_history(dataset_size, all_history):
+    history_mean_sim = []
+    history_edge_sup = []
+
+    current_pair_similarities = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the sum of all similarities of each pair combination
+    current_pair_counts       = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair is used in the bootstrapping
+    current_edge_support      = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair are each others closest k neighbours
+
+    for b, history in enumerate(sorted(all_history, key=lambda x: x["b"])):
+        current_pair_similarities += history["pair_sim_sum"]
+        current_pair_counts       += history["pair_counts"] 
+        current_edge_support      += history["edge_support"]
+
+        current_mean_similarities = np.divide(
+            current_pair_similarities,
+            current_pair_counts,
+            out=np.zeros_like(current_pair_similarities, dtype=float),
+            where=current_pair_counts != 0
+        )
+        current_mean_edge_support = current_edge_support / (b + 1)
+
+        history_mean_sim.append(current_mean_similarities)
+        history_edge_sup.append(current_mean_edge_support)
+
+    return history_mean_sim, history_edge_sup
+
 
 
 def _get_spectra_labels(label_mode: str, spectra_binned: list[Spectrum]) -> tuple[list[str], dict[str, any]]:  # Logic from previous main function refactored into a helper function

--- a/specreboot/bootstrapping/bootstrapping.py
+++ b/specreboot/bootstrapping/bootstrapping.py
@@ -1,278 +1,10 @@
 import numpy as np
-import pandas as pd
-from collections import defaultdict, Counter
-from matchms import calculate_scores
 from matchms import Spectrum
+from typing import Any
+from tqdm import tqdm
+import pandas as pd
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
-import time
-
-
-def _run_single_bootstrap(
-    b,
-    spectra_binned,
-    global_bins_arr,
-    internal_ids,
-    id_to_index,
-    similarity_metric,
-    seed,
-    k,
-    track_bins=False,
-):
-    """
-    Run a single bootstrap replicate on globally binned spectra.
-
-    Parameters
-    -------
-    b : int
-        Bootstrap replicate index.
-    spectra_binned : list[Spectrum]
-        List of binned spectra.
-    global_bins_arr : np.ndarray
-        Array of global m/z bins used for resampling.
-    internal_ids : list[str]
-        Internal identifiers for the spectra.
-    id_to_index : dict[str, int]
-        Mapping from internal spectrum id to matrix index.
-    similarity_metric : callable
-        Similarity function/object used in calculate_scores.
-    seed : int
-        Base random seed.
-    k : int
-        Number of nearest neighbors used for mutual-kNN calculation.
-    track_bins : bool
-        Whether to store sampled and missing bins for this replicate.
-
-    Returns
-    -------
-    dict: Dictionary containing bootstrap similarity sums, similarity counts,
-    edge support, and optionally sampled/missing bins.
-    """
-    rng = np.random.default_rng(seed + b)
-
-    N = len(spectra_binned)
-    P = len(global_bins_arr)
-
-    pair_sim_sum = defaultdict(float)
-    pair_counts = defaultdict(int)
-    edge_support = Counter()
-
-    # --- Sample global bins with replacement for this bootstrap replicate ---
-    sampled_indices = rng.integers(0, P, size=P)
-    sampled_bins_arr = np.unique(global_bins_arr[sampled_indices])
-
-    spectra_boot = []
-
-    for idx, (internal_id, spec) in enumerate(zip(internal_ids, spectra_binned)):
-        mz = spec.peaks.mz
-        intens = spec.peaks.intensities
-
-        mask = np.isin(mz, sampled_bins_arr)
-        mz_kept = mz[mask]
-        int_kept = intens[mask]
-
-        # --- Add a dummy peak if no bins were retained after resampling ---
-        if mz_kept.size == 0:
-            dummy_mz = float(global_bins_arr.max() + 1000.0 + idx)
-            mz_kept = np.array([dummy_mz], dtype="float32")
-            int_kept = np.array([1.0], dtype="float32")
-
-        meta = {**spec.metadata, "internal_id": internal_id}
-
-        spectra_boot.append(
-            Spectrum(
-                mz=mz_kept.astype("float32"),
-                intensities=int_kept.astype("float32"),
-                metadata=meta,
-            )
-        )
-
-    sim_matrix = np.zeros((N, N), dtype=float)
-
-    scores = calculate_scores(
-        references=spectra_boot,
-        queries=spectra_boot,
-        similarity_function=similarity_metric,
-        is_symmetric=True,
-    )
-
-    for item in scores:
-        if len(item) == 3:
-            ref_spec, qry_spec, sim_val = item
-        else:
-            (ref_spec, qry_spec), sim_val = item
-
-        i = id_to_index[ref_spec.metadata["internal_id"]]
-        j = id_to_index[qry_spec.metadata["internal_id"]]
-
-        if i == j:
-            continue
-
-        sim = float(sim_val[0])
-        sim_matrix[i, j] = sim
-        sim_matrix[j, i] = sim
-
-        key = tuple(sorted((internal_ids[i], internal_ids[j])))
-        pair_sim_sum[key] += sim
-        pair_counts[key] += 1
-
-    # --- Compute mutual-kNN based edge support for this bootstrap replicate ---
-    k_eff = min(k, N - 1)
-    all_knn = []
-
-    for i in range(N):
-        row = sim_matrix[i].copy()
-        row[i] = -np.inf
-        knn_i = np.argpartition(row, -k_eff)[-k_eff:]
-        knn_i = knn_i[np.argsort(row[knn_i])[::-1]]
-        all_knn.append(set(knn_i))
-
-    for i in range(N):
-        for j in all_knn[i]:
-            if i < j and i in all_knn[j]:
-                key = tuple(sorted((internal_ids[i], internal_ids[j])))
-                edge_support[key] += 1
-
-    result = {
-        "b": b,
-        "pair_sim_sum": pair_sim_sum,
-        "pair_counts": pair_counts,
-        "edge_support": edge_support,
-    }
-
-    if track_bins:
-        sampled_arr = np.unique(sampled_bins_arr)
-        missing_arr = np.setdiff1d(global_bins_arr, sampled_arr)
-        result["sampled_bins"] = sampled_arr
-        result["missing_bins"] = missing_arr
-
-    return result
-
-
-def run_bootstrap_batch(
-    batch_bootstrap_ids,
-    spectra_binned,
-    global_bins_arr,
-    internal_ids,
-    id_to_index,
-    similarity_metric,
-    seed,
-    k,
-    B,
-    collect_history=False,
-    track_bins=False,
-    verbose=False,
-):
-    """
-    Run a batch of bootstrap replicates.
-
-    Parameters
-    -------
-    batch_bootstrap_ids : list[int]
-        Bootstrap replicate indices to run in this batch.
-    spectra_binned : list[Spectrum]
-        List of binned spectra.
-    global_bins_arr : np.ndarray
-        Array of global m/z bins used for resampling.
-    internal_ids : list[str]
-        Internal identifiers for the spectra.
-    id_to_index : dict[str, int]
-        Mapping from internal spectrum id to matrix index.
-    similarity_metric : callable
-        Similarity function/object used in calculate_scores.
-    seed : int
-        Base random seed.
-    k : int
-        Number of nearest neighbors used for mutual-kNN support.
-    B : int
-        Total number of bootstrap replicates.
-    collect_history : bool
-        Whether to return per-bootstrap results instead of aggregated batch totals.
-    track_bins : bool
-        Whether to store sampled and missing bins for each bootstrap.
-    verbose : bool
-        Whether to print progress information.
-
-    Returns
-    -------
-    tuple or list:
-    - If collect_history is False:
-        returns aggregated batch results: (batch_pair_sim_sum, batch_pair_counts, batch_edge_support)
-    - If collect_history is True:
-        returns a list with one result dictionary per bootstrap replicate.
-    """
-    t_batch_start = time.perf_counter()
-
-    # --- Fast mode: No history or bin tracking ---
-    if not collect_history:
-        batch_pair_sim_sum = defaultdict(float)
-        batch_pair_counts = defaultdict(int)
-        batch_edge_support = Counter()
-
-        for b in batch_bootstrap_ids:
-            res = _run_single_bootstrap(
-                b=b,
-                spectra_binned=spectra_binned,
-                global_bins_arr=global_bins_arr,
-                internal_ids=internal_ids,
-                id_to_index=id_to_index,
-                similarity_metric=similarity_metric,
-                seed=seed,
-                k=k,
-                track_bins=False,
-            )
-
-            for key, val in res["pair_sim_sum"].items():
-                batch_pair_sim_sum[key] += val
-
-            for key, val in res["pair_counts"].items():
-                batch_pair_counts[key] += val
-
-            for key, val in res["edge_support"].items():
-                batch_edge_support[key] += val
-
-            if verbose and ((b + 1) % 10 == 0 or (b + 1) == B):
-                print(f"[bootstrap {b+1}] done", flush=True)
-
-        t_batch_end = time.perf_counter()
-        if verbose:
-            print(
-                f"Batch {batch_bootstrap_ids[0]+1}-{batch_bootstrap_ids[-1]+1} "
-                f"finished in {t_batch_end - t_batch_start:.2f} s",
-                flush=True,
-            )
-
-        return batch_pair_sim_sum, batch_pair_counts, batch_edge_support
-    
-    # --- History mode: Collect detailed results for each bootstrap ---
-    batch_results = []
-
-    for b in batch_bootstrap_ids:
-        res = _run_single_bootstrap(
-            b=b,
-            spectra_binned=spectra_binned,
-            global_bins_arr=global_bins_arr,
-            internal_ids=internal_ids,
-            id_to_index=id_to_index,
-            similarity_metric=similarity_metric,
-            seed=seed,
-            k=k,
-            track_bins=track_bins,
-        )
-        batch_results.append(res)
-
-        if verbose and ((b + 1) % 10 == 0 or (b + 1) == B):
-            print(f"[bootstrap {b+1}] done", flush=True)
-
-    t_batch_end = time.perf_counter()
-    if verbose:
-        print(
-            f"Batch {batch_bootstrap_ids[0]+1}-{batch_bootstrap_ids[-1]+1} "
-            f"finished in {t_batch_end - t_batch_start:.2f} s",
-            flush=True,
-        )
-
-    return batch_results
-
 
 def calculate_boostrapping(
     spectra_binned,
@@ -280,103 +12,107 @@ def calculate_boostrapping(
     B=100,
     k=5,
     similarity_metric=None,
-    n_jobs=4,
-    batch_size=10,
+    n_jobs=8,
     seed=42,
-    return_history=False,
-    track_bins=False,
-    label_mode="feature",
-    return_label_map=True,
-    verbose: bool = True,
+    label_mode: str = "feature",      # "feature" | "scan" | "internal"
+    batch_size: int = 10
 ):
     """
-    Calculate bootstrapped mean similarity and edge support matrices.
-
-    Parameters
-    -------
-    spectra_binned : list[Spectrum]
-        List of binned spectra.
-    global_bins : array-like
-        Global m/z bins used as the bootstrap sampling space.
-    B : int
-        Number of bootstrap replicates.
-    k : int
-        Number of nearest neighbors used for mutual-kNN edge support.
-    similarity_metric : Similarity function/object used in calculate_scores.
-    n_jobs : int
-        Number of workers used for parallel batch execution.
-    batch_size : int
-        Number of bootstrap replicates processed per batch.
-    seed : int
-        Base random seed for bootstrap resampling.
-    return_history : bool
-        Whether to return cumulative bootstrap history.
-    track_bins : bool
-        Whether to store sampled and missing bins for each bootstrap.
-    label_mode : str
-        Output label type. Options are "feature", "scan", or "internal".
-    return_label_map : bool
-        Whether to return the mapping between output labels and internal identifiers.
-    verbose : bool
-        Whether to print progress and timing information.
+    Bootstrapped mean similarity + mutual-kNN edge support.
 
     Returns
     -------
-    tuple:
-    If return_history is False and return_label_map is False:
-        (df_mean_sim, df_edge_sup)
-    If return_history is False and return_label_map is True:
-        (df_mean_sim, df_edge_sup, label_map)
+    If return_history is False:
+        df_mean_sim, df_edge_sup                 (and label_map if return_label_map True)
     If return_history is True:
-        (df_mean_sim, df_edge_sup, history)
-
-    Notes:
-    - Bootstraps are executed in batches and parallelized across workers.
-    - Edge support is calculated from mutual-kNN recovery across bootstraps.
+        df_mean_sim, df_edge_sup, history        (history may include label_map)
     """
-    if similarity_metric is None:
-        raise ValueError("similarity_metric must be provided")
+    # NOTE: due to floating point arithmatic, the resulting values in the cosine similarity matrix might differ with the orignal function with around <1e-7. 
+    
+    global_bins = np.array(global_bins)  # Important, a simple list will raise an error
 
-    if batch_size < 1:
-        raise ValueError("batch_size must be >= 1")
+    out_labels, label_info = _get_spectra_labels(label_mode, spectra_binned)
 
-    batch_size = min(batch_size, B)
+    dataset_size = len(spectra_binned)
 
-    if global_bins is None or not hasattr(global_bins, "__len__"):
-        raise TypeError(
-            "global_bins must be an array/list of bin m/z values. "
-            "Did you accidentally pass the global_bins *function* instead of the computed bins array?"
-        )
+    total_pair_similarities = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the sum of all similarities of each pair combination
+    total_pair_counts       = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair is used in the bootstrapping
+    total_edge_support      = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair are each others closest k neighbours
+
+    bootstrap_ids = list(range(B))
+    batches = [bootstrap_ids[i:i + batch_size] for i in range(0, B, batch_size)]
+
+    args = [(spectra_binned, global_bins, similarity_metric, k, b, seed) for b in batches]
+    with ThreadPoolExecutor(max_workers=n_jobs) as executor:
+        results = list(executor.map(lambda x: bootstrap_batch(*x), args))
+
+    for result in results:
+        pair_similarities, pair_counts, edge_support = result
+
+        # Add the results if this iteration
+        total_pair_similarities += pair_similarities
+        total_pair_counts       += pair_counts
+        total_edge_support      += edge_support
+
+     
+    # Get the average of similarities
+    mean_similarities = np.divide(
+        total_pair_similarities,
+        total_pair_counts,
+        out=np.zeros_like(total_pair_similarities, dtype=float),
+        where=total_pair_counts != 0
+    )
+    np.fill_diagonal(mean_similarities , 1)  # needed to exactly match original implementation; all spectra have a similarity of 1 to themselves
+    mean_edge_support = total_edge_support / B
+
+    # Needed to match correct return type
+    df_mean_sim = pd.DataFrame(mean_similarities, index=out_labels, columns=out_labels)
+    df_edge_sup = pd.DataFrame(mean_edge_support, index=out_labels, columns=out_labels)
+
+    # Return history according to settings
+    return df_mean_sim, df_edge_sup
 
 
+def bootstrap_batch(spectra_binned: list[Spectrum], global_bins: np.array, similarity_metric, k: int, b: list[int], seed: int):
+    dataset_size = len(spectra_binned)
+    random_generator = np.random.default_rng(seed)
 
-    def make_unique(labels):
-        """Make labels unique by appending a suffix to duplicated values"""
-        counts = Counter(labels)
-        seen = Counter()
-        out = []
-        for lab in labels:
-            lab = str(lab)
-            if counts[lab] == 1:
-                out.append(lab)
-            else:
-                seen[lab] += 1
-                out.append(f"{lab}__{seen[lab]}")
-        return out
+    total_pair_similarities = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the sum of all similarities of each pair combination
+    total_pair_counts       = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair is used in the bootstrapping
+    total_edge_support      = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair are each others closest k neighbours
 
-    N = len(spectra_binned)
-    global_bins_arr = np.asarray(global_bins)
+    for b in tqdm(b):
 
-    pair_sim_sum = defaultdict(float)
-    pair_counts = defaultdict(int)
-    edge_support = Counter()
+        masked_spectra, sampled_bins = _mask_spectra(random_generator, global_bins, spectra_binned)
 
+        # This is different now, but matches the internal workings of calculate_scores from matchms module
+        similarity_matrix = similarity_metric.matrix(masked_spectra, masked_spectra, array_type="numpy", is_symmetric=True)
+
+        top_k_nearest_neighbours = mutual_topk(similarity_matrix, k)
+
+        # Get the position of the pairs that we used in this iteration
+        similarity_matrix_binary        = (similarity_matrix != 0).astype(int)
+        top_k_nearest_neighbours_binary = (top_k_nearest_neighbours != 0).astype(int)
+
+        # Add the results if this iteration
+        total_pair_similarities += similarity_matrix
+        total_pair_counts       += similarity_matrix_binary
+        total_edge_support      += top_k_nearest_neighbours_binary
+
+    return (
+        total_pair_similarities, 
+        total_pair_counts,        
+        total_edge_support,    
+    )
+     
+
+
+def _get_spectra_labels(label_mode: str, spectra_binned: list[Spectrum]) -> tuple[list[str], dict[str, any]]:  # Logic from previous main function refactored into a helper function
     scan_labels = []
     feature_labels = []
     internal_ids = []
     id_to_index = {}
 
-    # --- Build scan, feature, and internal labels for each spectrum ---
     for idx, spec in enumerate(spectra_binned):
         md = spec.metadata
 
@@ -386,7 +122,6 @@ def calculate_boostrapping(
             or md.get("scan_number") or md.get("SCAN_NUMBER")
             or f"scan_{idx}"
         )
-
         scan_labels.append(str(scan_number))
 
         feature_id = md.get("feature_id", md.get("FEATURE_ID", f"feat_{idx}"))
@@ -396,192 +131,90 @@ def calculate_boostrapping(
         internal_ids.append(internal_id)
         id_to_index[internal_id] = idx
 
-    scan_labels_u = make_unique(scan_labels)
-    feature_labels_u = make_unique(feature_labels)
-    internal_ids_u = make_unique(internal_ids)
+    # make labels safe for DataFrames/graphs
+    scan_labels_u = __make_unique(scan_labels)
+    feature_labels_u = __make_unique(feature_labels)
+    internal_ids_u = __make_unique(internal_ids)
 
-    lm = label_mode.lower()
-
+    lm = (label_mode or "feature").lower()
     if lm == "scan":
         out_labels = scan_labels_u
     elif lm == "internal":
         out_labels = internal_ids_u
     else:
-        out_labels = feature_labels_u
+        out_labels = feature_labels_u  # default
 
-    label_map = pd.DataFrame(
-        {
-            "out_label": out_labels,
-            "scan": scan_labels,
-            "scan_unique": scan_labels_u,
-            "feature_id": feature_labels,
-            "feature_unique": feature_labels_u,
-            "internal_id": internal_ids,
-        }
-    )
+    label_map = pd.DataFrame({
+        "out_label": out_labels,
+        "scan": scan_labels,
+        "scan_unique": scan_labels_u,
+        "feature_id": feature_labels,
+        "feature_unique": feature_labels_u,
+        "internal_id": internal_ids,
+    })
+    label_info = dict(label_map=label_map, label_mode=lm)
+    return out_labels, label_info
 
-    collect_history = return_history or track_bins
 
-    bootstrap_ids = list(range(B))
-    batches = [
-        bootstrap_ids[i:i + batch_size]
-        for i in range(0, B, batch_size)
-    ]
+def __make_unique(labels: list[any]) -> list[str]:
+    counts = Counter(labels)
+    seen = Counter()
+    out = []
+    for lab in labels:
+        lab = str(lab)
+        if counts[lab] == 1:
+            out.append(lab)
+        else:
+            seen[lab] += 1
+            out.append(f"{lab}__{seen[lab]}")
+    return out
 
-    args = [
-        (
-            batch,
-            spectra_binned,
-            global_bins_arr,
-            internal_ids,
-            id_to_index,
-            similarity_metric,
-            seed,
-            k,
-            B,
-            collect_history,
-            track_bins,
-            verbose,
-        )
-        for batch in batches
-    ]
 
-    total_start = time.perf_counter()
-    if verbose:
-        print(
-            f"Running {B} bootstraps in {len(batches)} batches "
-            f"(batch_size={batch_size}) with {n_jobs} workers",
-            flush=True,
-        )
+def mutual_topk(A: np.ndarray, k: int) -> np.ndarray:
+    """ gives a matrix in the shap of A, where a 1 means a pair are each others top-k neighbor """
 
-    compute_start = time.perf_counter()
-    with ThreadPoolExecutor(max_workers=n_jobs) as executor:
-        results = list(executor.map(lambda x: run_bootstrap_batch(*x), args))
-    compute_end = time.perf_counter()
+    n = A.shape[0]
+    A_work = A.copy()
+    np.fill_diagonal(A_work, -np.inf)  # This makes sure self-similarity is not counted as a top neighbor
 
-    if verbose:
-        print(
-            f"Bootstrap batch execution finished in {compute_end - compute_start:.2f} seconds",
-            flush=True,
-        )
+    row_sorted = np.argsort(A_work, axis=1)  # Gives use the indices if the sorted values: [3, 2, 7, 1] -> [3, 1, 0, 2] (along one axis)
+    row_sorted = row_sorted[:, ::-1]  # Reverse the indices, so the index of the highest nr is first
+    row_topk = row_sorted[:, :k]  # Remove the part after the k-best neighbour
 
-    # --- Fast mode: aggregate batch results without reconstructing per-bootstrap history ---
-    if not collect_history:
-        if verbose:
-            print("Merging batch results...", flush=True)
+    row_mask = np.zeros_like(A_work, dtype=bool)
+    rows = np.arange(n)[:, None]  # Create a range of nrs [0, 1, 2, .., n] and make it 2d -> [[0, 1, 2, .., n]], needed to make mask
+    row_mask[rows, row_topk] = True  # Sets only the top neighbors to True
 
-        merge_start = time.perf_counter()
+    mutual_mask = row_mask & row_mask.T  # Only a value that is in *mutual* top k neighbors kept
 
-        for ps, pc, es in results:
-            for key, val in ps.items():
-                pair_sim_sum[key] += val
+    result = np.zeros_like(A)  
+    result[mutual_mask] = 1  # sets all the mutual top k neighbors to 1
+    return result
 
-            for key, val in pc.items():
-                pair_counts[key] += val
 
-            for key, val in es.items():
-                edge_support[key] += val
+def _mask_spectra(random_generator: Any, global_bins: np.ndarray, binned_spectra: list[Spectrum]) -> tuple[list[Spectrum], np.ndarray]:
+    result = []
 
-        merge_end = time.perf_counter()
-        total_end = time.perf_counter()
+    sampled_indices = random_generator.integers(0, len(global_bins), size=len(global_bins))
 
-        if verbose:
-            print(f"Merge finished in {merge_end - merge_start:.2f} seconds", flush=True)
-            print(f"Total bootstrapping completed in {total_end - total_start:.2f} seconds", flush=True)
+    sampled_bins = global_bins[sampled_indices]
+    sampled_bins = np.unique(sampled_bins)
 
-        mean_sim = np.eye(N, dtype="float32")
-        for (id_i, id_j), total in pair_sim_sum.items():
-            i = id_to_index[id_i]
-            j = id_to_index[id_j]
-            cnt = pair_counts[(id_i, id_j)]
-            mean_sim[i, j] = total / cnt
-            mean_sim[j, i] = total / cnt
+    for index, spectrum in enumerate(binned_spectra):
+        mask = np.isin(spectrum.peaks.mz, sampled_bins)
 
-        edge_mat = np.zeros((N, N), dtype="float32")
-        for (id_i, id_j), cnt in edge_support.items():
-            i = id_to_index[id_i]
-            j = id_to_index[id_j]
-            edge_mat[i, j] = cnt / B
-            edge_mat[j, i] = cnt / B
+        mz = spectrum.peaks.mz[mask] 
+        intensities = spectrum.peaks.intensities[mask]
 
-        df_mean_sim = pd.DataFrame(mean_sim, index=out_labels, columns=out_labels)
-        df_edge_sup = pd.DataFrame(edge_mat, index=out_labels, columns=out_labels)
+        mz = mz.astype("float32")
+        intensities = intensities.astype("float32")
 
-        if return_label_map:
-            return df_mean_sim, df_edge_sup, label_map
-        return df_mean_sim, df_edge_sup
+        if len(mz) == 0:
+            mz = np.array([ global_bins[0] ], dtype="float32")
+            intensities = np.array([0.0],     dtype="float32")
 
-    # --- History mode: reconstruct cumulative results from individual bootstraps ---
-    if verbose:
-        print("Reconstructing cumulative history from per-bootstrap results...", flush=True)
+        masked_spectrum = Spectrum(mz, intensities, spectrum.metadata)
+        result.append(masked_spectrum)
 
-    replay_start = time.perf_counter()
-
-    flat_results = []
-    for batch_res in results:
-        flat_results.extend(batch_res)
-
-    flat_results.sort(key=lambda x: x["b"])
-
-    hist_mean_sim = []
-    hist_edge_sup = []
-    hist_sampled_bins = []
-    hist_missing_bins = []
-
-    for res in flat_results:
-        for key, val in res["pair_sim_sum"].items():
-            pair_sim_sum[key] += val
-
-        for key, val in res["pair_counts"].items():
-            pair_counts[key] += val
-
-        for key, val in res["edge_support"].items():
-            edge_support[key] += val
-
-        cur_mean = np.eye(N, dtype="float32")
-        for (id_i, id_j), total in pair_sim_sum.items():
-            i = id_to_index[id_i]
-            j = id_to_index[id_j]
-            cnt = pair_counts[(id_i, id_j)]
-            cur_mean[i, j] = total / cnt
-            cur_mean[j, i] = total / cnt
-
-        cur_edge = np.zeros((N, N), dtype="float32")
-        denom = float(res["b"] + 1)
-        for (id_i, id_j), cnt in edge_support.items():
-            i = id_to_index[id_i]
-            j = id_to_index[id_j]
-            cur_edge[i, j] = cnt / denom
-            cur_edge[j, i] = cnt / denom
-
-        hist_mean_sim.append(cur_mean)
-        hist_edge_sup.append(cur_edge)
-
-        if track_bins:
-            hist_sampled_bins.append(res["sampled_bins"])
-            hist_missing_bins.append(res["missing_bins"])
-
-    replay_end = time.perf_counter()
-    total_end = time.perf_counter()
-
-    if verbose:
-        print(f"History reconstruction finished in {replay_end - replay_start:.2f} seconds", flush=True)
-        print(f"Total bootstrapping completed in {total_end - total_start:.2f} seconds", flush=True)
-
-    mean_sim = pd.DataFrame(hist_mean_sim[-1], index=out_labels, columns=out_labels)
-    edge_sup = pd.DataFrame(hist_edge_sup[-1], index=out_labels, columns=out_labels)
-
-    history = {
-        "mean_sim": hist_mean_sim,
-        "edge_sup": hist_edge_sup,
-    }
-
-    if track_bins:
-        history["sampled_bins"] = hist_sampled_bins
-        history["missing_bins"] = hist_missing_bins
-
-    if return_label_map:
-        history["label_map"] = label_map
-        history["label_mode"] = lm
-
-    return mean_sim, edge_sup, history
+    return result, sampled_bins
+    

--- a/specreboot/networking/networking.py
+++ b/specreboot/networking/networking.py
@@ -1,4 +1,5 @@
 from typing import Optional
+import numpy as np
 import pandas as pd
 import networkx as nx
 
@@ -100,20 +101,23 @@ def build_base_graph(
     _validate_matrix_pair(df_mean_sim, df_support)
 
     G = nx.Graph()
-    scan_ids = df_mean_sim.index.tolist()
+    scan_ids = [str(x) for x in df_mean_sim.index.tolist()]
     G.add_nodes_from(scan_ids)
 
+    sim = df_mean_sim.values
+    sup = df_support.values
     n = len(scan_ids)
-    for i in range(n):
-        for j in range(i + 1, n):
-            sim = df_mean_sim.iloc[i, j]
-            if sim >= sim_threshold:
-                sup = df_support.iloc[i, j]
-                G.add_edge(
-                    scan_ids[i], scan_ids[j],
-                    weight=sim,
-                    bootstrap_support=sup
-                )
+
+    i_idx, j_idx = np.triu_indices(n, k=1)
+    sim_vals = sim[i_idx, j_idx]
+    sup_vals = sup[i_idx, j_idx]
+
+    mask = sim_vals >= sim_threshold
+    edges = [
+        (scan_ids[i], scan_ids[j], {"weight": float(s), "bootstrap_support": float(p)})
+        for i, j, s, p in zip(i_idx[mask], j_idx[mask], sim_vals[mask], sup_vals[mask])
+    ]
+    G.add_edges_from(edges)
 
     # Only filter if parameter is provided
     if max_component_size is not None:
@@ -121,8 +125,6 @@ def build_base_graph(
 
     nx.write_graphml(G, output_file)
     return G
-
-
 
 
 # Function 2: Dual-threshold similarity + support graph
@@ -144,28 +146,29 @@ def build_thresh_graph(
     _validate_matrix_pair(df_mean_sim, df_support)
 
     G = nx.Graph()
-    scan_ids = df_mean_sim.index.tolist()
+    scan_ids = [str(x) for x in df_mean_sim.index.tolist()]
     G.add_nodes_from(scan_ids)
 
+    sim = df_mean_sim.values
+    sup = df_support.values
     n = len(scan_ids)
-    for i in range(n):
-        for j in range(i + 1, n):
-            sim = df_mean_sim.iloc[i, j]
-            sup = df_support.iloc[i, j]
-            if sim >= sim_threshold and sup >= support_threshold:
-                G.add_edge(
-                    scan_ids[i], scan_ids[j],
-                    weight=sim,
-                    bootstrap_support=sup
-                )
+
+    i_idx, j_idx = np.triu_indices(n, k=1)
+    sim_vals = sim[i_idx, j_idx]
+    sup_vals = sup[i_idx, j_idx]
+
+    mask = (sim_vals >= sim_threshold) & (sup_vals >= support_threshold)
+    edges = [
+        (scan_ids[i], scan_ids[j], {"weight": float(s), "bootstrap_support": float(p)})
+        for i, j, s, p in zip(i_idx[mask], j_idx[mask], sim_vals[mask], sup_vals[mask])
+    ]
+    G.add_edges_from(edges)
 
     if max_component_size is not None:
         _filter_components(G, max_component_size, cosine_delta)
 
     nx.write_graphml(G, output_file)
     return G
-
-
 
 
 # Function 3: Multi-class (core + rescued edges)
@@ -189,33 +192,31 @@ def build_core_rescue_graph(
     _validate_matrix_pair(df_mean_sim, df_support)
 
     G = nx.Graph()
-    scan_ids = df_mean_sim.index.tolist()
+    scan_ids = [str(x) for x in df_mean_sim.index.tolist()]
     G.add_nodes_from(scan_ids)
 
+    sim = df_mean_sim.values
+    sup = df_support.values
     n = len(scan_ids)
-    for i in range(n):
-        for j in range(i + 1, n):
-            sim = df_mean_sim.iloc[i, j]
-            sup = df_support.iloc[i, j]
 
-            if sim >= sim_core and sup >= support_core:
-                label = "core"
-            elif sim_rescue_min <= sim < sim_core and sup >= support_rescue:
-                label = "rescued"
-            else:
-                continue
+    i_idx, j_idx = np.triu_indices(n, k=1)
+    sim_vals = sim[i_idx, j_idx]
+    sup_vals = sup[i_idx, j_idx]
 
-            G.add_edge(
-                scan_ids[i], scan_ids[j],
-                weight=sim,
-                bootstrap_support=sup,
-                edge_class=label,
-            )
+    core_mask   = (sim_vals >= sim_core)       & (sup_vals >= support_core)
+    rescue_mask = (sim_vals >= sim_rescue_min)  & (sim_vals < sim_core) & (sup_vals >= support_rescue)
+    either_mask = core_mask | rescue_mask
+
+    labels = np.where(core_mask[either_mask], "core", "rescued").astype(str).astype(str)
+
+    edges = [
+        (scan_ids[i], scan_ids[j], {"weight": float(s), "bootstrap_support": float(p), "edge_class": str(lab)})
+        for i, j, s, p, lab in zip(i_idx[either_mask], j_idx[either_mask], sim_vals[either_mask], sup_vals[either_mask], labels)
+    ]
+    G.add_edges_from(edges)
 
     if max_component_size is not None:
         _filter_components(G, max_component_size, cosine_delta)
 
     nx.write_graphml(G, output_file)
     return G
-
-

--- a/specreboot/run_workflow_gnps.py
+++ b/specreboot/run_workflow_gnps.py
@@ -7,7 +7,7 @@ from matchms.similarity.FlashSimilarity import FlashSimilarity
 
 from specreboot.preprocessing.filtering import spectra_harmonization
 from specreboot.binning.binning import global_bins as make_global_bins, bin_spectra
-from specreboot.bootstrapping.bootstrapping import calculate_boostrapping
+from specreboot.bootstrapping.bootstrapping import calculate_bootstrapping
 from specreboot.networking.gnps_style import load_gnps_graph_and_id_map, add_threshold_edges_to_gnps_graph, add_rescued_edges_to_gnps_graph
 
 
@@ -229,7 +229,7 @@ def run(args):
     similarity = _make_similarity(args)
 
     # --- Run bootstrapping ----
-    result = calculate_boostrapping(
+    result = calculate_bootstrapping(
         binned_spectra,
         bins,
         B=args.B,

--- a/specreboot/run_workflow_matchms.py
+++ b/specreboot/run_workflow_matchms.py
@@ -245,16 +245,11 @@ def calculate_similarities(binned_spectra, bins, model_name: str, similarity, ar
         label_mode=args.label_mode,
     )
 
-    if args.return_history or args.track_bins:
-        df_mean_sim, df_edge_sup, history = result
-        df_mean_sim.to_csv(outdir / f"{args.prefix}_bootstrap_mean_similarity_{model_name}.csv")
-        df_edge_sup.to_csv(outdir / f"{args.prefix}_bootstrap_edge_support_{model_name}.csv")
-        return df_mean_sim, df_edge_sup, history
-
-    df_mean_sim, df_edge_sup = result
+    df_mean_sim, df_edge_sup, history = result
     df_mean_sim.to_csv(outdir / f"{args.prefix}_bootstrap_mean_similarity_{model_name}.csv")
     df_edge_sup.to_csv(outdir / f"{args.prefix}_bootstrap_edge_support_{model_name}.csv")
-    return df_mean_sim, df_edge_sup
+    return df_mean_sim, df_edge_sup, history
+
 
 
 def networking_score(df_mean_sim, df_edge_sup, similarity_score: str, sim_threshold: float, args, outdir: Path):
@@ -345,13 +340,12 @@ def run(args):
             args.outdir,
         )
 
-        if args.return_history or args.track_bins:
-            df_mean_sim, df_edge_sup, history = result
+        df_mean_sim, df_edge_sup, history = result
+
+        if history:
             with open(args.outdir / f"{args.prefix}_bootstrap_history_{model_name}.pkl", "wb") as f:
                 pickle.dump(history, f)
-        else:
-            df_mean_sim, df_edge_sup = result
-
+                
         sim_thr = args.sim_threshold_ms2dp if model_name == "MS2DeepScore" else args.sim_threshold
 
         networking_score(

--- a/specreboot/run_workflow_matchms.py
+++ b/specreboot/run_workflow_matchms.py
@@ -8,7 +8,7 @@ from matchms.similarity.FlashSimilarity import FlashSimilarity
 
 from specreboot.preprocessing.filtering import general_cleaning
 from specreboot.binning.binning import global_bins as make_global_bins, bin_spectra
-from specreboot.bootstrapping.bootstrapping import calculate_boostrapping
+from specreboot.bootstrapping.bootstrapping import calculate_bootstrapping
 from specreboot.networking.networking import build_base_graph, build_thresh_graph, build_core_rescue_graph
 
 
@@ -231,7 +231,7 @@ def _resolve_and_validate_similarities(args) -> list[str]:
 
 def calculate_similarities(binned_spectra, bins, model_name: str, similarity, args, outdir: Path):
     """Run bootstrapping for one similarity metric and export the output matrices."""
-    result = calculate_boostrapping(
+    result = calculate_bootstrapping(
         binned_spectra,
         bins,
         B=args.B,


### PR DESCRIPTION
This PR contains changes related to specreboot/bootstrapping.py, extracted from the broader parallel-bootstrap development branch.

**Main changes**

1. Transition to NumPy-based accumulation
  - Pairwise similarities, counts, and edge support are now accumulated using NumPy arrays instead of iterative or per bootstrap structures
  - Enables efficient vectorized computation of mean similarity (mean_similarities) & edge support (mean_edge_support)
  - Reduces overhead from repeated DataFrame operations and improves performance on large datasets

2. Batch-based parallel bootstrapping is conserved
 
3. Refactoring of the bootstrapping workflow
- Clear separation between orchestration (calculate_bootstrapping), batch execution (bootstrap_batch), and history reconstruction (_reconstruct_history).

4. Improved label handling
- Centralized label generation via _get_spectra_labels
- Ensures consistent mapping between spectra and output matrices

5. Transition to NumPy-based graph construction
- Edge selection is now performed directly on the upper triangle of the similarity and support matrices using NumPy indexing, avoiding nested Python loops over all node pairs.

6. Refactoring of component filtering
Introduced helper functions:
- prune_component_edges(...)
- filter_components(...)
- Oversized connected components are now pruned iteratively by removing the weakest internal edges
- Component IDs are assigned after filtering 

**Points that may deserve attention during review**
- Numerical differences due to NumPy operations: Small floating-point deviations (<1e-7) may occur compared to the previous implementation.
- Random seeding across batches: Each batch currently initializes the RNG with the same seed, worth confirming whether this is intended or if batch-specific variation is preferred
- Component pruning logic, as oversized components are reduced by repeatedly removing the weakest internal edge
- The  cosine_delta parameteris still passed through the filtering functions but is currently not used directly

**Notes**
I added detailed docstrings and inline comments explaining :
- function arguments
- return values
- key steps of the bootstrapping procedure

I tested this PR together with:
- the matchms workflow PR
- the GNPS workflow PR

and both workflows run correctly end-to-end.