### PR TITLE
Bottom up approach implemented in networking.py as from library_match…

### DIFF
--- a/specreboot/networking/gnps_style.py
+++ b/specreboot/networking/gnps_style.py
@@ -1,6 +1,49 @@
 import networkx as nx
+import numpy as np
 import pandas as pd
 from specreboot.networking.networking import _filter_components
+
+
+def _filter_graph_by_component_size(
+    G: nx.Graph,
+    max_component_size: int,
+    cosine_delta: float,
+) -> None:
+    """NetworkX adapter for _filter_components.
+
+    Translates the graph's edges into the numpy arrays expected by
+    _filter_components, runs the greedy union-find size filtering, then
+    removes any rejected edge directly from G.
+
+    Parameters
+    ----------
+    G : nx.Graph
+        The graph to filter. Edges are removed in-place.
+    max_component_size : int
+        Maximum allowed number of nodes in any connected component.
+    cosine_delta : float
+        Passed through to _filter_components (reserved, currently unused).
+
+    Returns
+    -------
+    None
+        G is modified in-place; edges that would cause a component to exceed
+        max_component_size are removed. No new graph is returned.
+    """
+    edges = list(G.edges(data=True))
+    if not edges:
+        return
+    node_idx = {n: i for i, n in enumerate(G.nodes())}
+    u_nodes = np.array([node_idx[u] for u, _, _ in edges])
+    v_nodes = np.array([node_idx[v] for _, v, _ in edges])
+    sim_array = np.array([d.get("weight", 0.0) for _, _, d in edges])
+    edge_mask = np.ones(len(edges), dtype=bool)
+    accepted = _filter_components(
+        edge_mask, u_nodes, v_nodes, sim_array, max_component_size, cosine_delta, retire_groups=True
+    )
+    for (u, v, _), keep in zip(edges, accepted):
+        if not keep:
+            G.remove_edge(u, v)
 
 def _make_node_only_copy(G_gnps: nx.Graph) -> nx.Graph:
     """
@@ -144,7 +187,7 @@ def add_threshold_edges_to_gnps_graph(
                 )
 
     if max_component_size is not None:
-        _filter_components(G, max_component_size, cosine_delta)
+        _filter_graph_by_component_size(G, max_component_size, cosine_delta)
 
     nx.write_graphml(G, output_file)
     return G
@@ -261,7 +304,7 @@ def add_rescued_edges_to_gnps_graph(
                 )
     
     if max_component_size is not None:
-        _filter_components(G, max_component_size, cosine_delta)
+        _filter_graph_by_component_size(G, max_component_size, cosine_delta)
 
     nx.write_graphml(G, output_file)
     return G

--- a/specreboot/networking/networking.py
+++ b/specreboot/networking/networking.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import numpy as np
 import pandas as pd
 import networkx as nx
@@ -8,7 +7,14 @@ import networkx as nx
 # ----------------------------------------------------------------------
 
 def _validate_matrix_pair(df_a: pd.DataFrame, df_b: pd.DataFrame) -> None:
-    """Validate that two DataFrames are square and aligned."""
+    """Validate that two DataFrames are square and aligned.
+
+    Parameters:
+    df_a : pd.DataFrame
+        First matrix (e.g. mean similarity).
+    df_b : pd.DataFrame
+        Second matrix (e.g. bootstrap support).
+    """
     if not isinstance(df_a, pd.DataFrame) or not isinstance(df_b, pd.DataFrame):
         raise TypeError("Both inputs must be pandas DataFrames.")
 
@@ -26,65 +32,128 @@ def _validate_matrix_pair(df_a: pd.DataFrame, df_b: pd.DataFrame) -> None:
 # Component filtering
 # ----------------------------------------------------------------------
 
-def _prune_component_edges(
-    graph: nx.Graph,
-    component_nodes,
-    cosine_delta: float
-) -> None:
-    """
-    Remove the lowest-weight edges within a component until it shrinks.
-    """
-    # Extract all edges inside this component
-    sub_edges = graph.subgraph(component_nodes).edges(data=True)
-
-    # Sort by edge weight (mean_similarity)
-    sorted_edges = sorted(sub_edges, key=lambda e: e[2].get("weight", 0.0))
-
-    if not sorted_edges:
-        return
-
-    # Remove the weakest edge
-    weakest_edge = sorted_edges[0]
-    u, v = weakest_edge[0], weakest_edge[1]
-    graph.remove_edge(u, v)
-
-
 def _filter_components(
-    graph: nx.Graph,
+    edge_mask: np.ndarray,
+    u_nodes: np.ndarray,
+    v_nodes: np.ndarray,
+    similarity_array: np.ndarray,
     max_component_size: int,
-    cosine_delta: float
-) -> None:
-    """
-    Iteratively prune oversized components by removing weakest edges.
+    cosine_delta: float,
+    retire_groups: bool,
+) -> np.ndarray:
+    """Greedily accept edges from strongest to weakest while keeping clusters below a size limit.
 
-    Parameters
-    ----------
-    graph : nx.Graph
-        The network to be filtered.
+    Edges are considered in descending similarity order. An edge is accepted
+    only if merging the two clusters it connects would not exceed
+    max_component_size. Once a cluster fails to merge (because it would grow
+    too large), it is optionally 'retired': subsequent edges that would touch a
+    retired cluster are skipped. This prevents a cluster that is already near
+    the size limit from later absorbing smaller clusters via weaker edges.
+
+    Cluster membership is tracked with a flat lookup array (union-find style):
+    each node stores the ID of its cluster, and the dominant cluster absorbs the
+    smaller one on every accepted merge.
+
+    Parameters:
+    edge_mask : np.ndarray
+        Boolean array of shape (E,) indicating which edges passed the
+        similarity/support thresholds and are candidates for inclusion.
+    u_nodes : np.ndarray
+        Row indices of the upper-triangle edge pairs, shape (E,).
+    v_nodes : np.ndarray
+        Column indices of the upper-triangle edge pairs, shape (E,).
+    similarity_array : np.ndarray
+        Similarity value for each edge, shape (E,).
     max_component_size : int
-        Maximum allowed connected component size (0 = disabled).
+        Maximum number of nodes allowed in a connected component.
     cosine_delta : float
-        Placeholder for future logic; currently not used directly.
+        Reserved parameter; not currently used in filtering logic.
+    retire_groups : bool
+        If True, clusters that fail a merge are frozen and will not
+        participate in any further merges.
+
+    Returns:
+    np.ndarray:
+        Boolean array of shape (E,) marking which edges are accepted after
+        component-size filtering. Combine with the original threshold mask
+        using & to get the final edge set.
     """
-    if max_component_size == 0:
-        return
+    retired_groups = set()
 
-    oversized_exists = True
+    nr_of_nodes = max(np.max(u_nodes), np.max(v_nodes)) + 1
+    node_groups = np.arange(nr_of_nodes)   # each node starts in its own singleton cluster
+    group_sizes = np.ones(nr_of_nodes)     # every cluster starts with size 1
 
-    while oversized_exists:
-        oversized_exists = False
-        components = list(nx.connected_components(graph))
+    # Work on a copy so the caller's array is not modified.
+    sim = similarity_array.copy()
+    sim[edge_mask == 0] = 0  # zero out edges that did not pass the threshold
 
-        for comp in components:
-            if len(comp) > max_component_size:
-                _prune_component_edges(graph, comp, cosine_delta)
-                oversized_exists = True
+    # Process edges from strongest to weakest.
+    indices = np.argsort(sim)[::-1]
 
-    # Assign component ID numbers
-    for cid, comp in enumerate(nx.connected_components(graph)):
+    mask = np.zeros_like(sim)
+
+    for i in indices:
+        strength = sim[i]
+        u, v = u_nodes[i], v_nodes[i]
+
+        if strength == 0:  # all remaining edges are zeroed out, nothing left to do
+            break
+
+        u_group = node_groups[u]  # look up current cluster of u
+        v_group = node_groups[v]  # look up current cluster of v
+
+        if retire_groups and any(g in retired_groups for g in [u_group, v_group]):
+            # At least one cluster is frozen; retire both to prevent partial absorption.
+            retired_groups.add(u_group)
+            retired_groups.add(v_group)
+            continue
+
+        if u_group == v_group:
+            # Edge is within an existing cluster — no size change, always accept.
+            mask[i] = 1
+            continue
+
+        u_group_size = group_sizes[u_group]
+        v_group_size = group_sizes[v_group]
+
+        if u_group_size + v_group_size > max_component_size:
+            # Merging would exceed the limit; retire both clusters.
+            retired_groups.add(u_group)
+            retired_groups.add(v_group)
+            continue
+
+        # Accept the merge and update cluster bookkeeping.
+        mask[i] = 1
+
+        # The lower-numbered group absorbs the higher-numbered one.
+        dominant_group, purged_group = sorted((u_group, v_group))
+        node_groups[node_groups == purged_group] = dominant_group
+        group_sizes[dominant_group] = u_group_size + v_group_size
+        group_sizes[purged_group] = 0
+
+    return mask.astype(bool)
+
+
+def _assign_cluster_ids(graph: nx.Graph) -> None:
+    """Assign a 'component' attribute to every node, sorted by component size.
+
+    The largest connected component receives id 0, the second largest id 1,
+    and so on. The attribute is written directly onto the graph nodes.
+
+    Parameters:
+    graph : nx.Graph
+        The graph whose nodes will be labelled.
+    """
+    components = sorted(nx.connected_components(graph), key=len, reverse=True)
+    for cid, comp in enumerate(components):
         for node in comp:
             graph.nodes[node]["component"] = cid
 
+
+# ----------------------------------------------------------------------
+# Graph builders
+# ----------------------------------------------------------------------
 
 def build_base_graph(
     df_mean_sim: pd.DataFrame,
@@ -94,9 +163,33 @@ def build_base_graph(
     cosine_delta: float = 0.02,
     output_file: str = "network_similarity.graphml",
 ) -> nx.Graph:
-    """
-    Build a graph where edges exist if mean similarity exceeds a threshold.
-    Component filtering is optional: enabled only if max_component_size is not None.
+    """Build a graph where edges exist if mean similarity meets a threshold.
+
+    Each pair of nodes (i, j) receives an edge when their mean bootstrapped
+    similarity is at or above sim_threshold. Component-size filtering is
+    applied before edges are added to the graph: edges are accepted greedily
+    from strongest to weakest, and any edge that would cause a cluster to
+    exceed max_component_size is rejected. Filtering is skipped when
+    max_component_size is None.
+
+    Parameters:
+    df_mean_sim : pd.DataFrame
+        Square matrix of mean pairwise bootstrapped similarities.
+    df_support : pd.DataFrame
+        Square matrix of mutual-kNN bootstrap support values (same shape).
+    sim_threshold : float
+        Minimum mean similarity required for an edge to be included.
+    max_component_size : int or None
+        Maximum allowed connected-component size. None disables filtering.
+    cosine_delta : float
+        Reserved parameter passed to the component filter; not currently used.
+    output_file : str
+        Path where the resulting graph is written as a GraphML file.
+
+    Returns:
+    nx.Graph:
+        The constructed graph with 'weight', 'bootstrap_support', and
+        'component' attributes on each edge/node.
     """
     _validate_matrix_pair(df_mean_sim, df_support)
 
@@ -108,26 +201,27 @@ def build_base_graph(
     sup = df_support.values
     n = len(scan_ids)
 
+    # Extract upper-triangle pairs to avoid counting each edge twice.
     i_idx, j_idx = np.triu_indices(n, k=1)
     sim_vals = sim[i_idx, j_idx]
     sup_vals = sup[i_idx, j_idx]
 
     mask = sim_vals >= sim_threshold
+
+    if max_component_size is not None:
+        mask &= _filter_components(mask, i_idx, j_idx, sim_vals, max_component_size, cosine_delta, retire_groups=True)
+
     edges = [
         (scan_ids[i], scan_ids[j], {"weight": float(s), "bootstrap_support": float(p)})
         for i, j, s, p in zip(i_idx[mask], j_idx[mask], sim_vals[mask], sup_vals[mask])
     ]
     G.add_edges_from(edges)
-
-    # Only filter if parameter is provided
-    if max_component_size is not None:
-        _filter_components(G, max_component_size, cosine_delta)
+    _assign_cluster_ids(G)
 
     nx.write_graphml(G, output_file)
     return G
 
 
-# Function 2: Dual-threshold similarity + support graph
 def build_thresh_graph(
     df_mean_sim: pd.DataFrame,
     df_support: pd.DataFrame,
@@ -137,11 +231,35 @@ def build_thresh_graph(
     cosine_delta: float = 0.02,
     output_file: str = "network_supported.graphml",
 ) -> nx.Graph:
-    """
-    Build a network where edges require both:
-        - similarity ≥ sim_threshold
-        - bootstrap support ≥ support_threshold
-    Component filtering is optional.
+    """Build a graph where edges require both a similarity and a support threshold.
+
+    An edge between nodes (i, j) is included only when their mean bootstrapped
+    similarity is at or above sim_threshold AND their mutual-kNN bootstrap
+    support is at or above support_threshold. The dual threshold makes this
+    graph more conservative than build_base_graph: edges must be both strong
+    and reproducible across bootstrap replicates. Component-size filtering
+    works identically to build_base_graph.
+
+    Parameters:
+    df_mean_sim : pd.DataFrame
+        Square matrix of mean pairwise bootstrapped similarities.
+    df_support : pd.DataFrame
+        Square matrix of mutual-kNN bootstrap support values (same shape).
+    sim_threshold : float
+        Minimum mean similarity required for an edge to be included.
+    support_threshold : float
+        Minimum bootstrap support required for an edge to be included.
+    max_component_size : int or None
+        Maximum allowed connected-component size. None disables filtering.
+    cosine_delta : float
+        Reserved parameter passed to the component filter; not currently used.
+    output_file : str
+        Path where the resulting graph is written as a GraphML file.
+
+    Returns:
+    nx.Graph:
+        The constructed graph with 'weight', 'bootstrap_support', and
+        'component' attributes on each edge/node.
     """
     _validate_matrix_pair(df_mean_sim, df_support)
 
@@ -158,20 +276,21 @@ def build_thresh_graph(
     sup_vals = sup[i_idx, j_idx]
 
     mask = (sim_vals >= sim_threshold) & (sup_vals >= support_threshold)
+
+    if max_component_size is not None:
+        mask &= _filter_components(mask, i_idx, j_idx, sim_vals, max_component_size, cosine_delta, retire_groups=True)
+
     edges = [
         (scan_ids[i], scan_ids[j], {"weight": float(s), "bootstrap_support": float(p)})
         for i, j, s, p in zip(i_idx[mask], j_idx[mask], sim_vals[mask], sup_vals[mask])
     ]
     G.add_edges_from(edges)
-
-    if max_component_size is not None:
-        _filter_components(G, max_component_size, cosine_delta)
+    _assign_cluster_ids(G)
 
     nx.write_graphml(G, output_file)
     return G
 
 
-# Function 3: Multi-class (core + rescued edges)
 def build_core_rescue_graph(
     df_mean_sim: pd.DataFrame,
     df_support: pd.DataFrame,
@@ -183,11 +302,43 @@ def build_core_rescue_graph(
     cosine_delta: float = 0.02,
     output_file: str = "network_multiclass.graphml",
 ) -> nx.Graph:
-    """
-    Build a graph with two edge classes:
-        - core
-        - rescued
-    Component filtering is optional.
+    """Build a graph that distinguishes core edges from rescued edges.
+
+    Edges fall into one of two classes:
+    - core    : similarity >= sim_core AND support >= support_core.
+    - rescued : sim_rescue_min <= similarity < sim_core AND support >= support_rescue.
+
+    The rescued class recovers pairs whose similarity is moderate but whose
+    bootstrap support is high enough to be considered reliable. Both classes
+    compete for the same component-size budget: the greedy filter processes
+    all candidate edges (core and rescued combined) in descending similarity
+    order, so a rescued edge is only accepted after all stronger core edges
+    have already been placed.
+
+    Parameters:
+    df_mean_sim : pd.DataFrame
+        Square matrix of mean pairwise bootstrapped similarities.
+    df_support : pd.DataFrame
+        Square matrix of mutual-kNN bootstrap support values (same shape).
+    sim_core : float
+        Minimum similarity for a core edge.
+    support_core : float
+        Minimum bootstrap support for a core edge.
+    sim_rescue_min : float
+        Minimum similarity for a rescued edge (must be < sim_core).
+    support_rescue : float
+        Minimum bootstrap support for a rescued edge.
+    max_component_size : int or None
+        Maximum allowed connected-component size. None disables filtering.
+    cosine_delta : float
+        Reserved parameter passed to the component filter; not currently used.
+    output_file : str
+        Path where the resulting graph is written as a GraphML file.
+
+    Returns:
+    nx.Graph:
+        The constructed graph with 'weight', 'bootstrap_support', 'edge_class',
+        and 'component' attributes on each edge/node.
     """
     _validate_matrix_pair(df_mean_sim, df_support)
 
@@ -203,20 +354,22 @@ def build_core_rescue_graph(
     sim_vals = sim[i_idx, j_idx]
     sup_vals = sup[i_idx, j_idx]
 
-    core_mask   = (sim_vals >= sim_core)       & (sup_vals >= support_core)
-    rescue_mask = (sim_vals >= sim_rescue_min)  & (sim_vals < sim_core) & (sup_vals >= support_rescue)
+    core_mask   = (sim_vals >= sim_core)      & (sup_vals >= support_core)
+    rescue_mask = (sim_vals >= sim_rescue_min) & (sim_vals < sim_core) & (sup_vals >= support_rescue)
     either_mask = core_mask | rescue_mask
 
-    labels = np.where(core_mask[either_mask], "core", "rescued").astype(str).astype(str)
+    if max_component_size is not None:
+        either_mask &= _filter_components(either_mask, i_idx, j_idx, sim_vals, max_component_size, cosine_delta, retire_groups=True)
+
+    # Determine the class of each surviving edge: core takes priority.
+    labels = np.where(core_mask[either_mask], "core", "rescued")
 
     edges = [
         (scan_ids[i], scan_ids[j], {"weight": float(s), "bootstrap_support": float(p), "edge_class": str(lab)})
         for i, j, s, p, lab in zip(i_idx[either_mask], j_idx[either_mask], sim_vals[either_mask], sup_vals[either_mask], labels)
     ]
     G.add_edges_from(edges)
-
-    if max_component_size is not None:
-        _filter_components(G, max_component_size, cosine_delta)
+    _assign_cluster_ids(G)
 
     nx.write_graphml(G, output_file)
     return G


### PR DESCRIPTION
**Summary**
Replaces the iterative graph-mutation approach to component-size filtering with a vectorized implementation that operates on edge masks before edges are added to the graph. Also adds full docstrings throughout networking.py.

**What is new?**

1. New _filter_components (replaces old _prune_component_edges + _filter_components). The previous implementation built the full graph, then iteratively removed the weakest edge from any oversized component and re-checked all components in a while loop. The new version processes candidate edges from strongest to weakest (bottom up) in a single pass, accepting an edge only if merging the two clusters it connects would not exceed max_component_size. Cluster membership is tracked with a flat lookup array (node_groups) and a sizes array (group_sizes), so merges are O(n) in the worst case rather than requiring repeated nx.connected_components calls.

2. Cluster retirement. When a candidate merge would exceed the size limit, both clusters involved are added to a retired_groups set and skipped for all subsequent edges. This prevents a near-full cluster from continuing to absorb smaller clusters via weaker edges, which the old "remove weakest until it shrinks" loop could not cleanly enforce.

3.New _assign_cluster_ids helper. Component IDs are now assigned in a separate, dedicated pass after the graph is built, sorted by component size (largest = id 0). Previously this was tangled inside _filter_components.

4. Filter applied before edge construction. All three builder functions (build_base_graph, build_thresh_graph, build_core_rescue_graph) now AND the component-filter mask into the threshold mask before iterating to construct edges. This avoids constructing then mutating the graph.

5. Docstrings. _validate_matrix_pair, the new helpers, and all three builder functions now have full Parameters/Returns docstrings. _filter_components includes prose explaining the greedy acceptance + retirement logic.

6. Minor cleanup. Removed the unused from typing import Optional import. Removed a redundant .astype(str).astype(str) chain on the edge-class labels in build_core_rescue_graph.

**Behavioral notes for review:**

1. cosine_delta is preserved in all signatures but remains unused (kept for backward compatibility with existing callers).

**A couple of things worth checking before you open it:**

1. Confirm that the new approach conserves the behavior of the old implementation for small and large networks.

2. If cosine_delta is not needed anymore at this point, this PR (or a follow-up) might be a good place to remove it indefinitely.