### PR TITLE
Cache cleaned spectra in workflow scripts to avoid re-cleaning

### DIFF
--- a/specreboot/run_workflow_gnps.py
+++ b/specreboot/run_workflow_gnps.py
@@ -217,9 +217,13 @@ def run(args):
     
     # --- Load and clean spectra ---
     spectra = list(load_from_mgf(str(args.mgf)))
-    cleaned_name = args.cleaned_mgf or str(args.outdir / f"{args.mgf.stem}_cleaned.mgf")
-    spectra_cleaned, report = spectra_harmonization(spectra, file_name=cleaned_name)
-    print(report)
+    cleaned_path = Path(args.cleaned_mgf or args.outdir / f"{args.mgf.stem}_cleaned.mgf")
+    if cleaned_path.exists():
+        spectra_cleaned = list(load_from_mgf(str(cleaned_path)))
+        print(f"Loaded {len(spectra_cleaned)} pre-cleaned spectra from {cleaned_path}")
+    else:
+        spectra_cleaned, report = spectra_harmonization(spectra, file_name=str(cleaned_path))
+        print(report)
 
     # --- Bin spectra for bootstrapping ---
     bins = make_global_bins(spectra_cleaned, args.decimals)

--- a/specreboot/run_workflow_matchms.py
+++ b/specreboot/run_workflow_matchms.py
@@ -285,10 +285,14 @@ def run(args):
     args.outdir.mkdir(parents=True, exist_ok=True)
 
     # --- Load and clean spectra ---
-    spectra = load_from_mgf(str(args.mgf))
-    cleaned_name = args.cleaned_mgf or str(args.outdir / f"{args.mgf.stem}_cleaned.mgf")
-    spectra_cleaned, report = general_cleaning(spectra, file_name=cleaned_name)
-    print(report)
+    spectra = list(load_from_mgf(str(args.mgf)))
+    cleaned_path = Path(args.cleaned_mgf or args.outdir / f"{args.mgf.stem}_cleaned.mgf")
+    if cleaned_path.exists():
+        spectra_cleaned = list(load_from_mgf(str(cleaned_path)))
+        print(f"Loaded {len(spectra_cleaned)} pre-cleaned spectra from {cleaned_path}")
+    else:
+        spectra_cleaned, report = general_cleaning(spectra, file_name=str(cleaned_path))
+        print(report)
 
     # --- Bin spectra for bootstrapping ---
     bins = make_global_bins(spectra_cleaned, args.decimals)


### PR DESCRIPTION
**Summary**
Both run_workflow_matchms.py and run_workflow_gnps.py now check for a previously cleaned MGF file before running the cleaning step. If the file exists, it is loaded directly; otherwise the raw spectra are cleaned and the result is saved. Previously, re-running a workflow would fail because general_cleaning / spectra_harmonization cannot overwrite an existing output file.

**What changed**

1. Cached-cleaning pattern in both run() functions. Each workflow now takes the form: load raw spectra → check if <outdir>/<prefix>_cleaned.mgf exists → if yes, load from cache; if no, run the cleaning step and write to that path.

2. Generator → list in run_workflow_matchms.py. The previous version passed load_from_mgf(...) directly (a generator) to general_cleaning. It now wraps the call in list(...) to match the style of run_workflow_gnps.py. No functional impact (I guess) general_cleaning uses the iterable either way, but it makes the two workflows structurally identical at this step, which matters because the cache-check logic is now also identical.

**Behavioral notes for review**

1. Cache invalidation is filename-based only: if the underlying raw MGF or the cleaning parameters change but the output filename does not, the stale cached file will be loaded silently.

2. The cache file lives in outdir, so different --outdir / --prefix combinations get independent caches automatically.