### PR TITLE
Modifications to bootstrapping to reduce memory usage

### DIFF
--- a/specreboot/bootstrapping/bootstrapping.py
+++ b/specreboot/bootstrapping/bootstrapping.py
@@ -64,7 +64,10 @@ def calculate_bootstrapping(
     """
     total_start = time.perf_counter()
 
-    # NOTE: due to floating point arithmatic, the resulting values in the cosine similarity matrix might differ with the orignal function with around <1e-7. 
+    if B > np.iinfo(np.uint16).max:
+        raise ValueError(f"B={B} exceeds uint16 max ({np.iinfo(np.uint16).max}); reduce B or change the dtype of total_pair_counts / total_edge_support.")
+
+    # NOTE: due to floating point arithmatic, the resulting values in the cosine similarity matrix might differ with the orignal function with around <1e-7.
     history = {}
 
     # The similarity implementation expects a NumPy array of global bins.

--- a/specreboot/bootstrapping/bootstrapping.py
+++ b/specreboot/bootstrapping/bootstrapping.py
@@ -77,8 +77,8 @@ def calculate_bootstrapping(
 
     # Accumulate results across all bootstrap replicates.
     total_pair_similarities = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the sum of all similarities of each pair combination
-    total_pair_counts       = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair is used in the bootstrapping
-    total_edge_support      = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair are each others closest k neighbours
+    total_pair_counts       = np.zeros((dataset_size, dataset_size), dtype=np.uint16)  # matrix with the nr of times a given pair is used in the bootstrapping
+    total_edge_support      = np.zeros((dataset_size, dataset_size), dtype=np.uint16)  # matrix with the nr of times a given pair are each others closest k neighbours
 
     bootstrap_ids = list(range(B))
     batches = [bootstrap_ids[i:i + batch_size] for i in range(0, B, batch_size)]
@@ -216,8 +216,8 @@ def bootstrap_batch(
 
     # Accumulate results across the bootstrap replicates in this batch.
     total_pair_similarities = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the sum of all similarities of each pair combination
-    total_pair_counts       = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair is used in the bootstrapping
-    total_edge_support      = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair are each others closest k neighbours
+    total_pair_counts       = np.zeros((dataset_size, dataset_size), dtype=np.uint16)  # matrix with the nr of times a given pair is used in the bootstrapping
+    total_edge_support      = np.zeros((dataset_size, dataset_size), dtype=np.uint16)  # matrix with the nr of times a given pair are each others closest k neighbours
 
     history = []
 
@@ -231,8 +231,8 @@ def bootstrap_batch(
         top_k_nearest_neighbours = mutual_topk(pair_similarity_matrix, k)
 
         # Get the position of the pairs that we used in this iteration
-        pair_counts  = (pair_similarity_matrix != 0).astype(int)
-        edge_support = (top_k_nearest_neighbours != 0).astype(int)
+        pair_counts  = (pair_similarity_matrix != 0).astype(np.uint8)
+        edge_support = (top_k_nearest_neighbours != 0).astype(np.uint8)
 
         # Add the results if this iteration
         total_pair_similarities += pair_similarity_matrix
@@ -285,8 +285,8 @@ def _reconstruct_history(dataset_size, all_history):
     history_edge_sup = []
 
     current_pair_similarities = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the sum of all similarities of each pair combination
-    current_pair_counts       = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair is used in the bootstrapping
-    current_edge_support      = np.zeros((dataset_size, dataset_size), dtype=float)  # matrix with the nr of times a given pair are each others closest k neighbours
+    current_pair_counts       = np.zeros((dataset_size, dataset_size), dtype=np.uint16)  # matrix with the nr of times a given pair is used in the bootstrapping
+    current_edge_support      = np.zeros((dataset_size, dataset_size), dtype=np.uint16)  # matrix with the nr of times a given pair are each others closest k neighbours
 
     for b, history in enumerate(sorted(all_history, key=lambda x: x["b"])):
         current_pair_similarities += history["pair_sim_sum"]
@@ -408,7 +408,7 @@ def mutual_topk(A: np.ndarray, k: int) -> np.ndarray:
 
     mutual_mask = row_mask & row_mask.T  # Only a value that is in *mutual* top k neighbors kept
 
-    result = np.zeros_like(A)  
+    result = np.zeros_like(A, dtype=np.uint8)
     result[mutual_mask] = 1  # sets all the mutual top k neighbors to 1
     return result
 


### PR DESCRIPTION
**Summary**
Reduces memory usage of bootstrapping.py by using smaller integer dtypes for count and indicator matrices. Outputs are bit-identical to the previous implementation, counts and 0/1 indicators are exact integers, only their representation changes. Motivated by an OOM crash on a 100,517-spectrum run: the original code allocated several (N, N) float64 matrices (~75 GiB each) to hold integer counts.

**Changes (in specreboot/bootstrapping/bootstrapping.py)**
1. total_pair_counts, total_edge_support: float64 → uint16 (max value = B)
2. pair_counts, edge_support (per-iteration): int64 → uint8 (binary indicators)
3. mutual_topk result: float64 → uint8 (function only writes 0 or 1)
4. Same changes mirrored in _reconstruct_history
5. total_pair_similarities intentionally left as float64 to preserve precision of the similarity sum

**Impact**
At N = 100,517, each (N, N) matrix drops from 75.3 GiB (float64) to 18.8 GiB (uint16) or 9.4 GiB (uint8). The dataset that previously OOM'd at ~189 GiB RSS now runs to completion at ~111 GiB.
Assumes B ≤ 65,535 (uint16 capacity); comfortable for realistic SpecReBoot runs.

**Verification**
1. Equivalence test (B=20, N=200): mean_similarity and mean_edge_support bit-identical (max abs diff = 0.00e+00)
2. 100,517-spectrum GNPS bile acid dataset: completed successfully
3. 112,086-spectrum GNPS bile acid dataset: completed successfully