### PR TITLE
feat: add spec2vec_allowed_missing_percentage parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Example — multiple selected metrics:
 | `--batch-size` | `10` | Replicates per thread-pool batch |
 | `--sim-threshold` | `0.7` | Mean similarity threshold for cosine/modcosine/spec2vec graphs |
 | `--sim-threshold-ms2dp` | `0.8` | Mean similarity threshold for MS2DeepScore graphs |
+| `--spec2vec-allowed-missing-percentage` | `5.0` | Maximum percentage of missing peaks allowed in spec2vec similarity calculation |
 | `--support-threshold` | `0.5` | Minimum edge support for threshold graph |
 | `--max-component-size` | `100` | Maximum connected-component size |
 | `--max-links` | `None` | Maximum edges per node; each node keeps only its top-N neighbours by mean similarity. `None` disables the filter |

--- a/specreboot/run_workflow_matchms.py
+++ b/specreboot/run_workflow_matchms.py
@@ -150,6 +150,15 @@ def build_parser(p: argparse.ArgumentParser):
             ),
     )
     p.add_argument(
+            "--spec2vec-allowed-missing-percentage",
+            type=float,
+            default=5.0,
+            help=(
+                "Maximum percentage of missing peaks allowed in spec2vec similarity calculation. "
+                "Prevents failed similarity calculations due to vocabulary gaps, particularly in specific cases involving self-trained models."
+            ),
+    )
+    p.add_argument(
             "--tolerance",
             type=float,
             default=0.01,
@@ -358,7 +367,7 @@ def run(args):
         similarity_objs["Spec2Vec"] = Spec2Vec(
             model=w2v,
             intensity_weighting_power=0.5,
-            allowed_missing_percentage=5.0,
+            allowed_missing_percentage=args.spec2vec_allowed_missing_percentage,
         )
 
     if "ms2deepscore" in sim_keys:


### PR DESCRIPTION
This PR introduces the spec2vec_allowed_missing_percentage parameter to the SpecReboot workflow, including updated documentation.

This parameter allows the maximum percentage of missing peaks allowed in the spec2vec similarity calculation to be customizable. Prevents failed similarity calculations due to vocabulary gaps, particularly in specific cases involving self-trained models. It is also important when working with specific (e.g. environmental non-target) data where the default missing percentage threshold of 5 might be too strict for unrepresented spectra.